### PR TITLE
feat: add Giscus comment system to blog posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -89,7 +89,7 @@ future                   : true
 read_more                : "disabled" # if enabled, adds "Read more" links to excerpts
 talkmap_link             : false #change to true to add link to talkmap on talks page
 comments:
-  provider               : # false (default), "disqus", "discourse", "facebook", "google-plus", "staticman", "custom"
+  provider               : "custom" # false (default), "disqus", "discourse", "facebook", "google-plus", "staticman", "custom"
   disqus:
     shortname            :
   discourse:

--- a/_includes/comments-providers/custom.html
+++ b/_includes/comments-providers/custom.html
@@ -1,3 +1,17 @@
 <!-- start custom comments snippet -->
-
+<script src="https://giscus.app/client.js"
+        data-repo="zhs2326/zhs2326.github.io"
+        data-repo-id="MDEwOlJlcG9zaXRvcnkxMzA0NzA4MDk="
+        data-category="General"
+        data-category-id="DIC_kwDOB8bTmc4C6mSm"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="0"
+        data-input-position="bottom"
+        data-theme="light"
+        data-lang="en"
+        crossorigin="anonymous"
+        async>
+</script>
 <!-- end custom comments snippet -->


### PR DESCRIPTION
## Summary
- Add [Giscus](https://giscus.app) comment system powered by GitHub Discussions
- Each post gets its own discussion thread mapped by URL pathname
- Emoji reactions enabled (👍 ❤️ 🎉 etc.) — easy one-click engagement
- Login via GitHub account; no ads, completely free

## Why Giscus
- **No ads** unlike Disqus free tier
- **GitHub-native** — comments stored as GitHub Discussions, no third-party data
- **Low friction** for technical audience who already have GitHub accounts
- **Reactions** let readers engage without writing a full comment

## ⚠️ One manual step required
To activate comments, install the Giscus GitHub App on this repo:
👉 https://github.com/apps/giscus → Install → select `zhs2326/zhs2326.github.io`

## Test plan
- [x] Jekyll build passes with no errors
- [x] Giscus script appears in rendered blog post HTML
- [x] GitHub Discussions enabled on repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)