### PR TITLE
feat: update ClustrMaps widget to show total visits

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -35,6 +35,6 @@ For more thoughts and ideas, please visit the [Blog Posts](/year-archive/) secti
 <div style="width: 60%; margin: auto;">
   <div class="visitor-map" style="text-align: center; margin-top: 2em;">
     <h3 class="archive__subtitle">Visitors</h3>
-    <script type="text/javascript" id="clustrmaps" src="//clustrmaps.com/map_v2.js?d=FRs1a0UImi5S_TLm9sIEWGyCMuleAZ1zMbYS80kk2U8&cl=ffffff&w=a"></script>
+    <script type="text/javascript" id="clustrmaps" src="//clustrmaps.com/map_v2.js?d=FRs1a0UImi5S_TLm9sIEWGyCMuleAZ1zMbYS80kk2U8&cl=ffffff&w=a&t=tt"></script>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Add `t=tt` parameter to ClustrMaps widget URL to switch from monthly to all-time total visit count
- Historical data is preserved server-side via the existing unique widget ID (`d=FRs1a0UImi5S_TLm9sIEWGyCMuleAZ1zMbYS80kk2U8`)

## Notes
- `t=tt` is referenced in community discussions as the "total time" parameter for ClustrMaps
- If the counter still shows monthly after deployment, log into clustrmaps.com, regenerate the widget with "Total Pageviews" selected, and update the embed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)