### PR TITLE
fix: remove compromised polyfill.io script (supply-chain malware)

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -33,7 +33,6 @@ window.MathJax = {
   }
 };
 </script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async
   src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
 </script>


### PR DESCRIPTION
## Problem

The site loaded `https://polyfill.io/v3/polyfill.min.js`. The **polyfill.io domain was hijacked in 2024** and now serves malware to visitors — including fake login popups (observed on the live site) and malicious redirects. This line shipped with the AcademicPages template and only existed to support MathJax on legacy browsers.

## Fix

Removes the single `polyfill.io` script tag from `_includes/head/custom.html`. MathJax 3 (loaded right below via jsDelivr) renders math fine without the ES6 polyfill on any modern browser, so no functionality is lost.

## Verification

- Math rendering still works (MathJax 3 self-contained)
- No remaining references to polyfill.io in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)