### PR TITLE
feat: replace ClustrMaps map with blocker-resistant GoatCounter counter

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -35,6 +35,25 @@ For more thoughts and ideas, please visit the [Blog Posts](/year-archive/) secti
 <div style="width: 60%; margin: auto;">
   <div class="visitor-map" style="text-align: center; margin-top: 2em;">
     <h3 class="archive__subtitle">Visitors</h3>
-    <script type="text/javascript" id="clustrmaps" src="//clustrmaps.com/map_v2.js?d=FRs1a0UImi5S_TLm9sIEWGyCMuleAZ1zMbYS80kk2U8&cl=ffffff&w=a&t=tt"></script>
+    <p id="visitor-count" style="font-size: 1.1em; color: #777;">Loading…</p>
   </div>
 </div>
+
+<script>
+  (function () {
+    var el = document.getElementById('visitor-count');
+    if (!el) { return; }
+    fetch('https://zhs2326.goatcounter.com/counter/TOTAL.json')
+      .then(function (r) {
+        if (!r.ok) { throw new Error('counter unavailable'); }
+        return r.json();
+      })
+      .then(function (d) {
+        el.textContent = d.count + ' total visits';
+      })
+      .catch(function () {
+        // Hide the section if the counter can't load (e.g. blocked or not enabled)
+        el.parentElement.style.display = 'none';
+      });
+  })();
+</script>


### PR DESCRIPTION
## Problem

The `Visitors` section rendered blank for many visitors. ClustrMaps' `map_v2.js` loads from `clustrmaps.com`, which is on common privacy/ad blocklists (EasyPrivacy), so blockers silently drop the request and only the heading remains.

## Fix

Replace the ClustrMaps map with **GoatCounter's site-wide TOTAL visitor counter**. GoatCounter is already used for analytics on this site, and the counter is served from our own `zhs2326.goatcounter.com` subdomain — which blockers rarely touch.

- Fetches the `/counter/TOTAL.json` endpoint and renders `N total visits` in text that matches the page typography.
- Gracefully **hides** the whole section if the request fails (blocked, or setting not yet enabled), so there's never an empty gap.

## ⚠️ Required action after merge

In GoatCounter, enable **Settings → "Allow adding visitor counts on your website"** (off by default). Until that's on, the JSON endpoint returns 403 and the section stays hidden. Note GoatCounter caches counts up to ~4 hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)