### PR TITLE
fix: visitor counter stuck on Loading (HTML minification broke inline JS)

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -44,16 +44,8 @@ For more thoughts and ideas, please visit the [Blog Posts](/year-archive/) secti
     var el = document.getElementById('visitor-count');
     if (!el) { return; }
     fetch('https://zhs2326.goatcounter.com/counter/TOTAL.json')
-      .then(function (r) {
-        if (!r.ok) { throw new Error('counter unavailable'); }
-        return r.json();
-      })
-      .then(function (d) {
-        el.textContent = d.count + ' total visits';
-      })
-      .catch(function () {
-        // Hide the section if the counter can't load (e.g. blocked or not enabled)
-        el.parentElement.style.display = 'none';
-      });
+      .then(function (r) { if (!r.ok) { throw new Error('counter unavailable'); } return r.json(); })
+      .then(function (d) { el.textContent = d.count + ' total visits'; })
+      .catch(function () { el.parentElement.style.display = 'none'; });
   })();
 </script>


### PR DESCRIPTION
## Problem

After switching to the GoatCounter counter, the Visitors section stayed stuck on **"Loading…"**.

Root cause: the Minimal Mistakes `compress` layout minifies the page and collapses the inline `<script>` onto a single line. The `// Hide the section…` line comment then commented out **everything after it on that line** — the `el.parentElement…` statement, the closing braces, and the `})()` call — leaving the function unterminated. That's a syntax error, so the script never executed and never updated (or hid) the element.

Verified the counter endpoint itself is healthy: `HTTP 200`, `{"count":"232"}`, and `Access-Control-Allow-Origin: *` — so CORS is fine; only the minification bug was at fault.

## Fix

Remove the `//` comment and keep each promise-chain step on a single self-contained statement, so the script stays valid even when minified to one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)