### PR TITLE
feat: self-hosted visitor world map (GoatCounter data, blocker-proof)

### DIFF
--- a/.github/workflows/visitor-map.yml
+++ b/.github/workflows/visitor-map.yml
@@ -1,0 +1,55 @@
+name: Update visitor map data
+
+# Pulls country-level visitor stats from the GoatCounter API and commits them
+# to assets/data/visitor-locations.json, which the About page renders as a map.
+# This keeps visitor data on our own domain so ad/privacy blockers can't blank it.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # daily at 03:00 UTC
+  workflow_dispatch:        # allow manual runs from the Actions tab
+
+permissions:
+  contents: write
+
+jobs:
+  update-data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Fetch location stats from GoatCounter
+        env:
+          GOATCOUNTER_API_TOKEN: ${{ secrets.GOATCOUNTER_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p assets/data
+          # limit=100 covers virtually every country for a personal site.
+          curl -sf \
+            -H "Authorization: Bearer ${GOATCOUNTER_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "https://zhs2326.goatcounter.com/api/v0/stats/locations?start=2020-01-01&limit=100" \
+            | jq '{
+                updated: (now | todate),
+                regions: [
+                  .stats[]
+                  | select(.id != null and .id != "")
+                  | {code: .id, name: .name, count: .count}
+                ]
+              }' \
+            > assets/data/visitor-locations.json
+          echo "Wrote $(jq '.regions | length' assets/data/visitor-locations.json) countries."
+
+      - name: Commit if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- assets/data/visitor-locations.json; then
+            echo "No changes to visitor data."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add assets/data/visitor-locations.json
+            git commit -m "chore: update visitor map data"
+            git push
+          fi

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -32,20 +32,52 @@ First author. Initiated the research idea, conducted the experiments, and wrote 
 
 For more thoughts and ideas, please visit the [Blog Posts](/year-archive/) section. I'm inspired by [Ziming Liu's blog](https://kindxiaoming.github.io/), where blog posts serve as an appropriate way to share ideas that might not be substantial enough for a full paper, yet can offer valuable observations and insights that may inspire others in the community. Most of my blog posts take less than 3 days to prepare.
 
-<div style="width: 60%; margin: auto;">
-  <div class="visitor-map" style="text-align: center; margin-top: 2em;">
-    <h3 class="archive__subtitle">Visitors</h3>
-    <p id="visitor-count" style="font-size: 1.1em; color: #777;">Loading…</p>
-  </div>
+<div id="visitor-section" style="max-width: 680px; margin: 2em auto 0;">
+  <h3 class="archive__subtitle" style="text-align: center;">Visitors</h3>
+  <div id="visitor-map" style="width: 100%; height: 360px;"></div>
+  <p id="visitor-count" style="text-align: center; font-size: 1.05em; color: #777; margin-top: 0.75em;"></p>
 </div>
 
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsvectormap@1.5.3/dist/css/jsvectormap.min.css">
+<script src="https://cdn.jsdelivr.net/npm/jsvectormap@1.5.3/dist/js/jsvectormap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jsvectormap@1.5.3/dist/maps/world.js"></script>
 <script>
   (function () {
-    var el = document.getElementById('visitor-count');
-    if (!el) { return; }
-    fetch('https://zhs2326.goatcounter.com/counter/TOTAL.json')
-      .then(function (r) { if (!r.ok) { throw new Error('counter unavailable'); } return r.json(); })
-      .then(function (d) { el.textContent = d.count + ' total visits'; })
-      .catch(function () { el.parentElement.style.display = 'none'; });
+    fetch('/assets/data/visitor-locations.json?_cache=' + (new Date().getTime()))
+      .then(function (r) { if (!r.ok) { throw new Error('no data'); } return r.json(); })
+      .then(function (data) {
+        var values = {};
+        var total = 0;
+        var countries = 0;
+        (data.regions || []).forEach(function (x) {
+          if (!x.code) { return; }
+          values[String(x.code).toUpperCase()] = x.count;
+          total += x.count;
+          countries += 1;
+        });
+        var countEl = document.getElementById('visitor-count');
+        if (countEl) {
+          countEl.textContent = total > 0
+            ? (total.toLocaleString() + ' visits from ' + countries + ' ' + (countries === 1 ? 'country' : 'countries'))
+            : 'Visitor data is syncing…';
+        }
+        if (typeof jsVectorMap === 'undefined') { return; }
+        new jsVectorMap({
+          selector: '#visitor-map',
+          map: 'world',
+          zoomButtons: false,
+          backgroundColor: 'transparent',
+          regionStyle: { initial: { fill: '#e8e8e8', stroke: '#ffffff', strokeWidth: 0.4 } },
+          series: { regions: [{ attribute: 'fill', scale: ['#cfe8ff', '#08519c'], normalizeFunction: 'polynomial', values: values }] },
+          onRegionTooltipShow: function (event, tooltip, code) {
+            var c = values[code] || 0;
+            tooltip.text(tooltip.text() + ': ' + c + (c === 1 ? ' visit' : ' visits'), true);
+          }
+        });
+      })
+      .catch(function () {
+        var wrap = document.getElementById('visitor-section');
+        if (wrap) { wrap.style.display = 'none'; }
+      });
   })();
 </script>

--- a/assets/data/visitor-locations.json
+++ b/assets/data/visitor-locations.json
@@ -1,0 +1,4 @@
+{
+  "updated": null,
+  "regions": []
+}


### PR DESCRIPTION
## What

Replaces the plain visitor count with a **choropleth world map** colored by country-level visits, with per-country tooltips.

## Why this design

A visitor map needs per-location data. Third-party map widgets (ClustrMaps, RevolverMaps) fetch that from *their* domain — exactly what ad/privacy blockers target, which is why ClustrMaps showed blank. So instead we render from **our own GoatCounter data, served from our own domain**:

- A daily GitHub Action (`/.github/workflows/visitor-map.yml`) calls GoatCounter `GET /api/v0/stats/locations` and commits `assets/data/visitor-locations.json`.
- The About page fetches that JSON from `/assets/...` (same origin — blockers don't touch it) and draws the map.
- Only the map *library* (jsVectorMap) loads from jsDelivr, which is not on privacy blocklists.

Graceful states: grey "syncing" map before the first data sync; section hides itself if the data file is unreachable.

## ⚠️ Manual setup required (only you can do this)

1. **GoatCounter API token** — log in to https://zhs2326.goatcounter.com → *Settings → Password, MFA, and API → API tokens* → create a token with **Read statistics** permission. Copy it.
2. **GitHub secret** — repo *Settings → Secrets and variables → Actions → New repository secret*: name `GOATCOUNTER_API_TOKEN`, value = the token.
3. **First run** — *Actions* tab → *Update visitor map data* → *Run workflow*. After it commits the data, the map fills in.

Until those are done, the page shows a grey map with "Visitor data is syncing…" (no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)