### PR TITLE
Organize blog posts into categories with refined archive styling

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -18,7 +18,7 @@ main:
   #   url: /portfolio/
         
   - title: "Blog Posts"
-    url: /year-archive/
+    url: /categories/
     
   # - title: "CV"
   #   url: /cv/

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -47,7 +47,7 @@
         {% endif %}
 
     {% if post.excerpt and site.read_more != 'enabled' %}
-    <p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify }}</p>
+    <p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | remove: '<p>' | remove: '</p>' }}</p>
     {% elsif post.excerpt and site.read_more == 'enabled' %}
     <p class="archive__item-excerpt" itemprop="description"><p>{{ post.excerpt | markdownify | remove: '<p>' | remove: '</p>' }}<strong><a href="{{ base_path }}{{ post.url }}" rel="permalink"> Read more</a></strong></p></p>
     {% endif %}

--- a/_pages/category-archive.html
+++ b/_pages/category-archive.html
@@ -1,17 +1,32 @@
 ---
 layout: archive
 permalink: /categories/
-title: "Posts by Category"
+title: "Blog Posts"
 author_profile: true
 ---
 
 {% include base_path %}
-{% include group-by-array collection=site.posts field="categories" %}
 
-{% for category in group_names %}
-  {% assign posts = group_items[forloop.index0] %}
-  <h2 id="{{ category | slugify }}" class="archive__subtitle">{{ category }}</h2>
-  {% for post in posts %}
-    {% include archive-single.html %}
-  {% endfor %}
+{% assign ordered_categories = "Continual Learning,Automatic Speech Recognition,Small Experiments,Reflections" | split: "," %}
+
+{% comment %} Render the curated categories first, in the order defined above {% endcomment %}
+{% for category in ordered_categories %}
+  {% assign posts = site.categories[category] %}
+  {% if posts %}
+    <h2 id="{{ category | slugify }}" class="archive__subtitle">{{ category }}</h2>
+    {% for post in posts %}
+      {% include archive-single.html %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}
+
+{% comment %} Render any remaining categories not listed above {% endcomment %}
+{% for cat_pair in site.categories %}
+  {% assign cat_name = cat_pair[0] %}
+  {% unless ordered_categories contains cat_name %}
+    <h2 id="{{ cat_name | slugify }}" class="archive__subtitle">{{ cat_name }}</h2>
+    {% for post in cat_pair[1] %}
+      {% include archive-single.html %}
+    {% endfor %}
+  {% endunless %}
 {% endfor %}

--- a/_posts/2025-06-01-learning-without-forgetting.md
+++ b/_posts/2025-06-01-learning-without-forgetting.md
@@ -2,6 +2,8 @@
 title: 'Paper Reading: Learning without Forgetting'
 date: 2025-06-01
 permalink: /posts/2025/06/blog-post-1/
+categories:
+  - Continual Learning
 tags:
   - continual learning
 excerpt: ""

--- a/_posts/2025-06-29-Overcoming Catastrophic Forgetting in Neural Network.md
+++ b/_posts/2025-06-29-Overcoming Catastrophic Forgetting in Neural Network.md
@@ -2,6 +2,8 @@
 title: 'Paper Reading: Overcoming Catastrophic Forgetting in Neural Network'
 date: 2025-06-29
 permalink: /posts/2025/06/blog-post-2/
+categories:
+  - Continual Learning
 tags:
   - continual learning
 excerpt: ""

--- a/_posts/2025-07-07-Progressive Neural Networks.md
+++ b/_posts/2025-07-07-Progressive Neural Networks.md
@@ -2,6 +2,8 @@
 title: 'Paper Reading: Progressive Neural Networks'
 date: 2025-07-07
 permalink: /posts/2025/07/blog-post-2/
+categories:
+  - Continual Learning
 tags:
   - continual learning
 excerpt: ""

--- a/_posts/2025-11-09-I Tested AI Detectors on My Daily Feeds — Here’s What I Found.md
+++ b/_posts/2025-11-09-I Tested AI Detectors on My Daily Feeds — Here’s What I Found.md
@@ -2,6 +2,8 @@
 title: 'I Tested AI Detectors on My Daily Feeds — Here’s What I Found'
 date: 2025-11-09
 permalink: /posts/2025/11/blog-post-1/
+categories:
+  - Small Experiments
 tags:
   - ai detector
 excerpt: ""

--- a/_posts/2026-03-21-Conformer.md
+++ b/_posts/2026-03-21-Conformer.md
@@ -2,6 +2,8 @@
 title: 'Conformer: Combining CNNs and Transformers for Speech Recognition'
 date: 2026-03-21
 permalink: /posts/2026/03/blog-post-1/
+categories:
+  - Automatic Speech Recognition
 tags:
   - speech recognition
   - deep learning

--- a/_posts/2026-04-11-reflections-as-a-newbie-tech-lead.md
+++ b/_posts/2026-04-11-reflections-as-a-newbie-tech-lead.md
@@ -2,6 +2,8 @@
 title: 'Reflections as a Newbie Tech Lead'
 date: 2026-04-11
 permalink: /posts/2026/04/blog-post-1/
+categories:
+  - Reflections
 tags:
   - leadership
   - career

--- a/_sass/_archive.scss
+++ b/_sass/_archive.scss
@@ -28,11 +28,13 @@
 }
 
 .archive__subtitle {
-  margin: 1.414em 0 0;
-  padding-bottom: 0.5em;
-  font-size: $type-size-5;
-  color: mix(#fff, $gray, 25%);
-  border-bottom: 1px solid $border-color;
+  margin: 2em 0 0.75em;
+  padding-bottom: 0.3em;
+  font-size: 1.4em; // larger than posts, smaller than the "Blog Posts" page title
+  font-weight: bold;
+  letter-spacing: 0.02em;
+  color: $text-color;
+  border-bottom: 2px solid $link-color;
 
   + .list__item .archive__item-title {
     margin-top: 0.5em;
@@ -42,6 +44,19 @@
 .archive__item-title {
   margin-bottom: 0.25em;
   font-family: $sans-serif-narrow;
+  font-size: $type-size-5;
+  font-weight: 600;
+  color: $text-color;
+
+  a {
+    color: $text-color;
+    text-decoration: none;
+
+    &:hover {
+      color: $link-color;
+      text-decoration: underline;
+    }
+  }
 
   a + a {
     opacity: 0.5;
@@ -58,8 +73,9 @@
 }
 
 .archive__item-excerpt {
-  margin-top: 0;
-  font-size: $type-size-6;
+  margin-top: 0.25em;
+  font-size: $type-size-6 * 0.95; // just a touch larger than the meta line (0.85)
+  color: $dark-gray;
 
   & + p {
     text-indent: 0;
@@ -102,8 +118,22 @@
     padding-right: $right-sidebar-width-wide;
   }
 
-  .page__meta {
-    margin: 0 0 4px;
+  // read-time and "Published:" date share one line
+  .page__meta,
+  .page__date {
+    display: inline-block;
+    margin: 0;
+    font-size: $type-size-6 * 0.85;
+    color: mix(#fff, $gray, 25%);
+  }
+
+  .page__meta + .page__date {
+    margin-left: 1em; // gap between read-time and date
+  }
+
+  // higher specificity than ".page__content p" so the size actually applies
+  .archive__item-excerpt {
+    font-size: $type-size-6 * 0.95; // just a touch larger than the meta line (0.85)
   }
 }
 


### PR DESCRIPTION
## Summary
Reorganizes the Blog Posts page to group posts under four categories and gives the archive a cleaner visual hierarchy.

**Categories**
- **Continual Learning** — Learning without Forgetting · Overcoming Catastrophic Forgetting · Progressive Neural Networks
- **Automatic Speech Recognition** — Conformer
- **Small Experiments** — I Tested AI Detectors on My Daily Feeds
- **Reflections** — Reflections as a Newbie Tech Lead

## Changes
- Add `categories` front matter to each post (URLs unchanged — posts use explicit permalinks).
- Rewrite `_pages/category-archive.html` to render the curated categories in a fixed order, with a fallback that appends any future uncategorized category.
- Point the **Blog Posts** nav link to `/categories/`.
- Restyle the archive (`_sass/_archive.scss`): category headings are bold with an accent underline (smaller than the page title); post titles are strong dark text with a teal hover; read-time and published date now share one compact line; description is smaller secondary text.
- Fix excerpt rendering in `_includes/archive-single.html`: strip `markdownify`'s wrapping `<p>` (nested `<p>` was being discarded by the browser, leaving the text unstyled) and raise selector specificity so the description size actually applies.

## Testing
Verified locally with `jekyll serve` — the page builds cleanly and renders categories in the intended order with the correct type hierarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)