### PR TITLE
docs: make Branchformer post excerpt a concise intro

### DIFF
--- a/_posts/2026-07-07-Branchformer.md
+++ b/_posts/2026-07-07-Branchformer.md
@@ -8,7 +8,7 @@ tags:
   - speech recognition
   - deep learning
   - transformer
-excerpt: "A follow-up to Conformer that replaces the fixed attention-then-convolution stacking with two parallel branches — self-attention for global context and a convolutional gated MLP for local context — making the interplay of local and global modeling both more flexible and more interpretable."
+excerpt: "My notes on Branchformer, a parallel two-branch alternative to Conformer for ASR encoding."
 ---
 
 # Branchformer


### PR DESCRIPTION
Rewrites the Branchformer post excerpt so it introduces the post itself (rather than describing Branchformer) and is more concise.

Before:
> A follow-up to Conformer that replaces the fixed attention-then-convolution stacking with two parallel branches — self-attention for global context and a convolutional gated MLP for local context — making the interplay of local and global modeling both more flexible and more interpretable.

After:
> My notes on Branchformer, a parallel two-branch alternative to Conformer for ASR encoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)