### PR TITLE
feat: show per-post view count via busuanzi

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,6 +15,8 @@
   document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';
 </script>
 
+<script async src="//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js"></script>
+
 <!-- For all browsers -->
 <link rel="stylesheet" href="{{ base_path }}/assets/css/main.css">
 

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -30,6 +30,11 @@ layout: default
           {% if page.read_time %}
             <p class="page__meta"><i class="fa fa-clock-o" aria-hidden="true"></i> {% include read-time.html %}</p>
           {% endif %}
+          {% if page.collection == 'posts' %}
+            <p class="page__meta" id="busuanzi_container_page_pv" style="display:none">
+              <i class="fa fa-eye" aria-hidden="true"></i> <span id="busuanzi_value_page_pv"></span> views
+            </p>
+          {% endif %}
         {% if page.modified %}
           <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Published:" }}</strong> <time datetime="{{ page.modified | date: "%Y-%m-%d" }}">{{ page.modified | date: "%B %d, %Y" }}</time></p>
         {% endif %}


### PR DESCRIPTION
## Summary
- Load the [busuanzi](https://busuanzi.ibruce.info/) script asynchronously from `_includes/head.html`.
- In `_layouts/single.html`, render a `views` meta line under the read-time on post pages only (guarded by `page.collection == 'posts'`).

## Notes
- Zero-config, no signup, no API keys. Counts are per-URL and populate live in the browser.
- The counter container starts with `display:none`; busuanzi reveals it once the count is fetched — so if the CDN is unreachable, nothing is shown (graceful degradation).
- Only shows on individual post pages, not on the year-archive listing (busuanzi has no per-URL API for that case).

## Test plan
- [x] Ran Jekyll locally and confirmed `busuanzi_container_page_pv` renders in the rendered HTML for `/posts/2026/07/blog-post-1/`.
- [x] Confirmed the container is NOT rendered on `/about/`.
- [ ] After merge + Pages deploy, load a post in a browser and verify the view count populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)